### PR TITLE
Provide demo build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "iron-reference"
 version = "0.1.0"
 authors = ["heartsucker <heartsucker@autistici.org>"]
+build = "build.rs"
 
 [[bin]]
 name = "iron-reference"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+fn main() {
+    compile_sass();
+}
+
+fn compile_sass() {
+    assert!(Command::new("sass")
+        .arg("--scss")
+        .arg("--style")
+            .arg("expanded")
+        .arg("--sourcemap=none")
+        .arg("scss/styles.scss:static/css/styles.css")
+        .status()
+        .expect("scss not compiled :(")
+        .success());
+
+    // Only rebuild `build.rs` process if these these have changed:
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=scss/styles.scss");
+}


### PR DESCRIPTION
Consider using a `build.rs` instead of a `Makefile`. Not sure how to handle the log level info in your run.

Feel free to discard. I've just been using build scripts lately, thought it might be useful.